### PR TITLE
Fix README path for partial templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ felixbarros/
 ├── assets/
 │   ├── css/input.css          # Entrada para Tailwind
 │   └── build/style.css        # Generado automáticamente
-├── templates/                 # Vistas parciales
+├── parts/                     # Vistas parciales
 ├── functions.php              # Configuración del tema
 ├── header.php / footer.php    # Estructura principal
 ├── index.php / page.php       # Plantillas básicas


### PR DESCRIPTION
## Summary
- update the project tree section in `README.md`
- ensure README ends with a trailing newline

## Testing
- `npm test`
- `composer validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840573767e08320b6c15641d8fe48ab