### PR TITLE
Fix typo in release workflow comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,4 @@ jobs:
           username: ${{ secrets.FTP_USER }}
           password: ${{ secrets.FTP_PASSWORD }}
           local-dir: './'                     # carpeta local donde está tu theme
-          server-dir: '/wp-content/themes/felixbarros/'  # ruta en el servidor, tambien se puede suarl el tag como nombre de la carpeta ${{ needs.release.outputs.new_tag }}
+          server-dir: '/wp-content/themes/felixbarros/'  # ruta en el servidor, tambien se puede usar el tag como nombre de la carpeta ${{ needs.release.outputs.new_tag }}


### PR DESCRIPTION
## Summary
- fix typo in `.github/workflows/release.yml`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840578862f483208029a912c3cf160c