### PR TITLE
Add ESLint and Prettier setup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/
+assets/build/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  extends: ['eslint:recommended', 'prettier'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  rules: {},
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100
+}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,14 @@ npm run dev
 npm run build
 ```
 
-4. Activar el tema desde el panel de WordPress
+4. Ejecutar linting y formateo (opcional):
+
+```bash
+npm run lint
+npm run format
+```
+
+5. Activar el tema desde el panel de WordPress
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "prepare": "husky install",
     "test": "echo \"No hay pruebas definidas\" && exit 0",
+    "lint": "eslint .",
+    "format": "prettier --write .",
     "release": "standard-version --config changelog.config.js",
     "dev": "npx tailwindcss -i ./assets/css/input.css -o ./assets/build/style.css --watch",
     "build": "npx tailwindcss -i ./assets/css/input.css -o ./assets/build/style.css --minify"
@@ -28,7 +30,10 @@
     "husky": "^8.0.0",
     "postcss": "^8.5.3",
     "semantic-release": "^24.2.3",
-    "tailwindcss": "^3.4.1"
+    "tailwindcss": "^3.4.1",
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5",
+    "eslint-config-prettier": "^9.1.0"
   },
   "dependencies": {
     "browserslist": "^4.24.4",


### PR DESCRIPTION
## Summary
- add ESLint and Prettier configs
- ignore build output for linting
- expose `lint` and `format` scripts and add devDependencies
- document how to run lint/format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684364c01d048320b7f2f4f09f86849d