### PR TITLE
Add typed.js typing effect in header

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,1 +1,10 @@
-// JS personalizado aquí
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof Typed !== 'undefined') {
+    new Typed('#typed-dev', {
+      strings: ['DEV'],
+      typeSpeed: 80,
+      backSpeed: 40,
+      loop: true
+    });
+  }
+});

--- a/functions.php
+++ b/functions.php
@@ -58,10 +58,19 @@ function felixbarros_enqueue_assets() {
         );
         wp_add_inline_script( 'highlightjs', 'document.addEventListener("DOMContentLoaded",function(){hljs.highlightAll();});' );
 
+        // typed.js para animar texto en el header
+        wp_enqueue_script(
+                'typedjs',
+                'https://cdn.jsdelivr.net/npm/typed.js@2.0.16',
+                array(),
+                '2.0.16',
+                true
+        );
+
         wp_enqueue_script(
                 'main-js',
                 get_template_directory_uri() . '/assets/js/main.js',
-                array(),
+                array( 'typedjs' ),
                 filemtime( get_template_directory() . '/assets/js/main.js' ),
                 true
         );

--- a/header.php
+++ b/header.php
@@ -24,7 +24,7 @@
 		<div class="flex items-center gap-2">
 			<span class="text-white font-title text-2xl font-black tracking-tight">Felix Barros</span>
 			<span class="w-px h-5 bg-white opacity-30"></span>
-			<span class="text-accent text-lg font-semibold">DEV</span>
+                        <span id="typed-dev" class="text-accent text-lg font-semibold">DEV</span>
 		</div>
 		</a>
 


### PR DESCRIPTION
## Summary
- load typed.js library and depend on it for main.js
- initialize the typing effect in `main.js`
- mark the DEV span with an id so the script can target it

## Testing
- `npm test`
- `composer analyse` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436870c91883208297de382a170397