### PR TITLE
Fix MIME type error loading Typed.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [1.2.0](https://github.com/felixbarrosdev/felixbarros/compare/v1.1.1...v1.2.0) (2025-06-06)
 
+### Bug Fixes
+
+* update Typed.js CDN path to avoid MIME type error
+
 
 ### Features
 

--- a/functions.php
+++ b/functions.php
@@ -60,8 +60,8 @@ function felixbarros_enqueue_assets() {
 
         // typed.js para animar texto en el header
         wp_enqueue_script(
-                'typedjs',
-                'https://cdn.jsdelivr.net/npm/typed.js@2.0.16',
+               'typedjs',
+               'https://cdn.jsdelivr.net/npm/typed.js@2.0.16/dist/typed.umd.min.js',
                 array(),
                 '2.0.16',
                 true


### PR DESCRIPTION
## Summary
- update typed.js CDN path so WordPress gets the file as `application/javascript`
- note fix in CHANGELOG

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68436d2d0d208320b8d951b00e7b4078