### PR TITLE
Add Composer install step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --dev
       - id: semantic_release
         run: npx semantic-release
         env:


### PR DESCRIPTION
## Summary
- install PHP dependencies in the release workflow before running `semantic-release`

## Testing
- `composer install --no-interaction --prefer-dist --dev` *(fails: missing PHP extensions)*
- `npm test` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684382b1bcec8320a42fb1c0a8e7e407